### PR TITLE
enhancements and fixes for Binary Input Channels Experiment

### DIFF
--- a/experiment-descriptor.json
+++ b/experiment-descriptor.json
@@ -40,7 +40,7 @@
     {
       "target": "index.html",
       "source": "simulation/binary_erasure_channel.html",
-      "label": "Binary Channels",
+      "label": "Simulation",
       "unit-type": "task",
       "content-type": "simulation"
     },

--- a/experiment/aim.md
+++ b/experiment/aim.md
@@ -1,3 +1,1 @@
-### Aim of the experiment
-
 This experiment will enable the user to understand the above aspects of these channels. The user is expected to know basics of probability distributions (such as Bernoulli, Binomial, and Gaussian distributions) and the notion of conditional probability, to execute this experiment. The user should ideally read the theory part of this experiment first, before attempting the questions. 

--- a/experiment/pretest.json
+++ b/experiment/pretest.json
@@ -46,7 +46,7 @@
         "d": "$p_X(0)=0.3,\\hspace{0.2cm} p_X(1)=0.6$."
       },
       "explanations": {
-        "a": "Wrong answer. This option is a valid Binomial distribution, not a Bernoulli distribution.",
+        "a": "Incorrect answer. This option is a valid Binomial distribution, not a Bernoulli distribution.",
         "b": "Incorrect answer. A Bernoulli random variable takes only two values.",
         "c": "Correct answer! A Bernoulli random variable takes two possible values (often represented as $0$ or $1$), and the probabilities should sum to $1$.",
         "d": "Incorrect answer! A Bernoulli random variable does take only two possible values (often represented as $0$ or $1$. However their probabilities should sum to $1$."

--- a/experiment/procedure.md
+++ b/experiment/procedure.md
@@ -1,5 +1,3 @@
-### Procedure
-
 The experiment consists of three sub-experiments, through which the user will be systematically understanding the essential mathematical aspects of three important probabilistic channels, discussed in the theory part of this experiment. These channels are : 
 
 1. The Binary Erasure Channel, which erases each bit transmitted independently with probability $\epsilon$. The erasure symbol is denoted by $?$. 
@@ -8,7 +6,7 @@ The experiment consists of three sub-experiments, through which the user will be
 
 The detailed working of this experiment is as follows. 
 
-## Overview of the Experiment window
+### Overview of the Experiment window
 
 <div style="text-align: center;">
     <img src="images/exp_window.png" alt="Experiment Window" width="75%"/>
@@ -21,11 +19,11 @@ The experiment window consists of the following components:
 4. **Observation box**: The observation box displays the feedback messages based on the user's input.
 5. **Action box**: The action box contains the input elements and buttons to perform the task.
 
-## Experiment 1: Binary Input Discrete Memoryless Channels
+### Experiment 1: Binary Input Discrete Memoryless Channels
 
 There are three tasks in this sub-experiment.
 
-### Task 1: Binary Erasure Channel
+#### Task 1: Binary Erasure Channel
 
 1. **Select Output Vectors**: Select the possible output vectors ($\vec{y}$) of the Binary Erasure Channel $BEC(\epsilon)$ whose input vector $\vec{x}$ is given. After selection, the boxes will turn green and deselecting them will turn them to gray.
     <div style="text-align: center;"> <img src="images/becexp_1.png" alt="alt text" width="75%"/> </div>
@@ -59,7 +57,7 @@ There are three tasks in this sub-experiment.
     <img src="images/becobs25.png" alt="alt text" width="25%"/>
     </div>
 
-### Task 2: Binary Symmetric Channel
+#### Task 2: Binary Symmetric Channel
 
 1. **Select Output Vectors**: Select the possible output vectors ($\vec{y}$) of the Binary Symmetric Channel $BSC(p)$ whose input vector $\vec{x}$ is given. After selection, the boxes will turn green and deselecting them will turn them to gray.
     <div style="text-align: center;"> <img src="images/bscexp_1.png" alt="alt text" width="75%"/> </div>
@@ -93,7 +91,7 @@ There are three tasks in this sub-experiment.
     <img src="images/becobs25.png" alt="alt text" width="25%"/>
     </div>
 
-### Task 3: Additive White Gaussian Noise Channel
+#### Task 3: Additive White Gaussian Noise Channel
 
 1. **Enter probability values**: According to the statement about the AWGN channel displayed, enter the values in the input boxes provided in the expression that represents the probability density of the output.
     <div style="text-align: center;"> <img src="images/awgnexp_1.png" alt="alt text" width="75%"/> </div>

--- a/experiment/simulation/binary_erasure_channel.html
+++ b/experiment/simulation/binary_erasure_channel.html
@@ -30,7 +30,7 @@
             </div>
             <div class="column">
                 <div class="v-tabs">
-                    <ul>
+                    <ul class="taskbar-tabs">
                         <li class="is-active" id="Task1">
                             <a>
                                 Binary Erasure Channel

--- a/experiment/simulation/binary_erasure_channel.html
+++ b/experiment/simulation/binary_erasure_channel.html
@@ -16,7 +16,7 @@
 
     <script type="text/javascript" id="MathJax-script" async
         src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
-        <script src="https://canvasjs.com/assets/script/canvasjs.min.js"></script>
+    <script src="https://canvasjs.com/assets/script/canvasjs.min.js"></script>
 
 </head>
 
@@ -63,10 +63,12 @@
                         <ul style="list-style: disc;">
                             <b>Quick theory overview:</b>
                             <li>
-                                <p>For the \( BEC(\epsilon) \) memoryless channel, the transition probability is given by:</p>
-                                <p style="text-align: center;">
-                                    \( p({y}|{x}) = \begin{cases} \epsilon^{w_e(y)}(1-\epsilon)^{n-w_e(y)} & \text{if} \ {x} \ \text{and} \ {y} \ \text{are compatible} \\ 0 & \text{otherwise} \end{cases}\)
-                                </p>
+                                <p>For the \( BEC(\epsilon) \) memoryless channel, the transition probability is given
+                                    by:</p>
+                                <div class="math-container">
+                                    \( p({y}|{x}) = \begin{cases} \epsilon^{w_e(y)}(1-\epsilon)^{n-w_e(y)} & \text{if} \
+                                    {x} \ \text{and} \ {y} \ \text{are compatible} \\ 0 & \text{otherwise} \end{cases}\)
+                                </div>
                             </li>
                         </ul>
                         <br>
@@ -78,26 +80,34 @@
                             </li>
 
                             <li>
-                                In the first exercise, you are given a codeword, and you have to identify what are the possible outputs of the Binary Erasure Channel.
+                                In the first exercise, you are given a codeword, and you have to identify what are the
+                                possible outputs of the Binary Erasure Channel.
                             </li>
 
                             <li>
-                                After selecting the output vectors accordingly, click on the <b>Submit</b> button. Observations will be displayed accordingly.
+                                After selecting the output vectors accordingly, click on the <b>Submit</b> button.
+                                Observations will be displayed accordingly.
                             </li>
                             <li>
-                                Only after you have selected all the correct output vectors will the <b>Next</b> button appear to go to the next exercise.
+                                Only after you have selected all the correct output vectors will the <b>Next</b> button
+                                appear to go to the next exercise.
                             </li>
                             <li>
-                                Click on the <b>Reset</b> button to reset all your selected choices and restart the exercise.
+                                Click on the <b>Reset</b> button to reset all your selected choices and restart the
+                                exercise.
                             </li>
                             <li>
-                                For the next exercise you must enter the probability of receiving each of the previously selected output vectors, from the input codeword, in the boxes given.
+                                For the next exercise you must enter the probability of receiving each of the previously
+                                selected output vectors, from the input codeword, in the boxes given.
                             </li>
                             <li>
-                                Once you have entered all the values, click on the <b>Submit</b> button. Observations will be displayed accordingly.
+                                Once you have entered all the values, click on the <b>Submit</b> button. Observations
+                                will be displayed accordingly.
                             </li>
                             <li>
-                                Click on the <b>Previous</b> button to go back to the first exercise or the <b>Reset</b> button to reset all your selected choices and restart the experiment from the first exercise.
+                                Click on the <b>Previous</b> button to go back to the first exercise or the <b>Reset</b>
+                                button to reset all your selected choices and restart the experiment from the first
+                                exercise.
                             </li>
                         </ul>
                     </div>
@@ -108,14 +118,15 @@
     <br>
 
 
-    
-    
+
+
     <section id="becp1" style="display:block ;">
         <div class="columns is-centered">
             <div class="column is-11-desktop is-12-tablet is-12-mobile">
                 <div class="v-datalist-container components-list">
                     <div>
-                        <p>A codeword needs to be sent through a Binary Symmetric Channel \( (BEC(\epsilon)) \) as shown below. Select the possible vectors that could be received through this channel.</p>
+                        <p>A codeword needs to be sent through a Binary Symmetric Channel \( (BEC(\epsilon)) \) as shown
+                            below. Select the possible vectors that could be received through this channel.</p>
                         <div class="box">
                             <p> \( {x} =\) [<label id="sentCodword"></label>] &rarr;</p>
                             <IMG src="./images/bec.png" alt="Binary Erasure Channel" style="width:125px;height:125px;">
@@ -126,122 +137,124 @@
             </div>
         </div>
 
-            <div class="columns is-centered is-flex-direction-row is-flex-wrap-wrap is-align-content-start"
-                style="margin-top:-1.5%;">
-                <div class="column is-8-desktop is-12-tablet is-12-mobile">
-                    <div class="box-question">
-                        
-                        
-                            <form action="" method="get" id="fb1" onsubmit="return false">
-                            <table align="center">
-                                <tr>
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="b1" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="b2" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="b3" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="b4" onClick="change(id)"></button>
-                                    </div></td>
-                                </tr>
-        
-                                <tr>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="b5" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="b6" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="b7" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="b8" onClick="change(id)"></button>
-                                    </div></td>
-                                </tr>
-                            </table>
-                            </form>
-                            <br>
-                            <button class="v-button" role="button" onClick= "checkb1()"> Submit </button>
-					        <button class="v-button" role="button" onClick= "reset()"> Reset </button>
-					        <button class="v-button" role="button" id = "nextpagebuttonb" role="button" style="display:none ;" onclick = "nextpage()"> Next </button>
-                        </div>    
-                    </div>
-                <div class="column is-3-desktop is-4-tablet is-12-mobile">
-                    <div class="v-datalist-container components-list">
-                        <div class="v-datalist-title">Observations</div>
-                        <div id="becobs1">
-    
-                        </div>
-                        <div id="becobs12">
-    
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        </section>
+        <div class="columns is-centered is-flex-direction-row is-flex-wrap-wrap is-align-content-start"
+            style="margin-top:-1.5%;">
+            <div class="column is-8-desktop is-12-tablet is-12-mobile">
+                <div class="box-question">
 
-            <section id="becp2" style="display:none ;">
-                <div class="columns is-centered">
-                    <div class="column is-11-desktop is-12-tablet is-12-mobile">
-                        <div class="v-datalist-container components-list">
-                            <p>For the input codeword \( {x} =\) [<p id="newCodword"></p>] enter the probability of receiving each of the previously selected output vectors on the &nbsp; \(  BEC(\epsilon)  \) &nbsp; channel.</p>
+
+                    <form action="" method="get" id="fb1" onsubmit="return false">
+                        <div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 15px;">
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="b1" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="b2" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="b3" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="b4" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="b5" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="b6" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="b7" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="b8" onClick="change(id)"></button>
+                            </div>
                         </div>
-                    </div>
-                </div>
-                <div class="columns is-centered is-flex-direction-row is-flex-wrap-wrap is-align-content-start" style="margin-top:-1.5%;">
-                    <div class="column is-8-desktop is-12-tablet is-12-mobile">
-                        <div class="box-question">
-                        <form action="" method="get" id="fb2" onsubmit="return false">
+                    </form>
                     <br>
-                    <div>
-                        <p style="margin-bottom: 50px;">Enter the probability of receiving each of the previously selected vectors.</p>
-                    <ul>
-                        <li>
-                            <span> (a) Enter the probability of receiving the vector \( {y} =\) <label id = "codewordb1"></label>.</span>
-                        </li>
-                        <p>\( p({y}|{x}) = \)<label>\( \epsilon \)<sup><input type="number" id="q11" style="width: 2em;"></sup></label>\( (1- \epsilon ) \)<sup><input type="number" id="q12" style="width: 2em;"></sup></p>
-                        <li>
-                            <span> (b) Enter the probability of receiving the vector \( {y} =\) <label id = "codewordb2"></label>.</span>
-                        </li>
-                        <p>\( p({y}|{x}) = \)<label>\( \epsilon \)<sup><input type="number" id="q21" style="width: 2em;"></sup></label>\( (1- \epsilon ) \)<sup><input type="number" id="q22" style="width: 2em;"></sup></p>
-                        <li>
-                            <span> (c) Enter the probability of receiving the vector \( {y} =\) <label id = "codewordb3"></label>.</span>
-                        </li>
-                        <p>\( p({y}|{x}) = \)<label> \( \epsilon \) <sup><input type="number" id="q31" style="width: 2em;"></sup></label>\( (1- \epsilon ) \)<sup><input type="number" id="q32" style="width: 2em;"></sup></p>
-                    </ul>
-                    </div>
-                </form>
-                <br>
-                <button class="v-button" role="button" onclick="checkb2()">Submit</button>
-                <button class="v-button" role="button" onClick= "reset()"> Reset </button>
-                <button class="v-button" role="button" onclick = "prevpage()"> Previous </button>  
-            </div>    
-        </div>
-    <div class="column is-3-desktop is-4-tablet is-12-mobile">
-        <div class="v-datalist-container components-list">
-            <div class="v-datalist-title">Observations</div>
-            <div id="becobs2">
+                    <button class="v-button" role="button" onClick="checkb1()"> Submit </button>
+                    <button class="v-button" role="button" onClick="reset()"> Reset </button>
+                    <button class="v-button" role="button" id="nextpagebuttonb" role="button" style="display:none ;"
+                        onclick="nextpage()"> Next </button>
+                </div>
+            </div>
+            <div class="column is-3-desktop is-4-tablet is-12-mobile">
+                <div class="v-datalist-container components-list">
+                    <div class="v-datalist-title">Observations</div>
+                    <div id="becobs1">
 
+                    </div>
+                    <div id="becobs12">
+
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-</div>
-</div>
-</section>
- 
+        </div>
+    </section>
+
+    <section id="becp2" style="display:none ;">
+        <div class="columns is-centered">
+            <div class="column is-11-desktop is-12-tablet is-12-mobile">
+                <div class="v-datalist-container components-list">
+                    <p>For the input codeword \( {x} =\) [
+                    <p id="newCodword"></p>] enter the probability of receiving each of the previously selected output
+                    vectors on the &nbsp; \( BEC(\epsilon) \) &nbsp; channel.</p>
+                </div>
+            </div>
+        </div>
+        <div class="columns is-centered is-flex-direction-row is-flex-wrap-wrap is-align-content-start"
+            style="margin-top:-1.5%;">
+            <div class="column is-8-desktop is-12-tablet is-12-mobile">
+                <div class="box-question">
+                    <form action="" method="get" id="fb2" onsubmit="return false">
+                        <br>
+                        <div>
+                            <p style="margin-bottom: 50px;">Enter the probability of receiving each of the previously
+                                selected vectors.</p>
+                            <ul>
+                                <li>
+                                    <span> (a) Enter the probability of receiving the vector \( {y} =\) <label
+                                            id="codewordb1"></label>.</span>
+                                </li>
+                                <p>\( p({y}|{x}) = \)<label>\( \epsilon \)<sup><input type="number" id="q11"
+                                                style="width: 2em;"></sup></label>\( (1- \epsilon ) \)<sup><input
+                                            type="number" id="q12" style="width: 2em;"></sup></p>
+                                <li>
+                                    <span> (b) Enter the probability of receiving the vector \( {y} =\) <label
+                                            id="codewordb2"></label>.</span>
+                                </li>
+                                <p>\( p({y}|{x}) = \)<label>\( \epsilon \)<sup><input type="number" id="q21"
+                                                style="width: 2em;"></sup></label>\( (1- \epsilon ) \)<sup><input
+                                            type="number" id="q22" style="width: 2em;"></sup></p>
+                                <li>
+                                    <span> (c) Enter the probability of receiving the vector \( {y} =\) <label
+                                            id="codewordb3"></label>.</span>
+                                </li>
+                                <p>\( p({y}|{x}) = \)<label> \( \epsilon \) <sup><input type="number" id="q31"
+                                                style="width: 2em;"></sup></label>\( (1- \epsilon ) \)<sup><input
+                                            type="number" id="q32" style="width: 2em;"></sup></p>
+                            </ul>
+                        </div>
+                    </form>
+                    <br>
+                    <button class="v-button" role="button" onclick="checkb2()">Submit</button>
+                    <button class="v-button" role="button" onClick="reset()"> Reset </button>
+                    <button class="v-button" role="button" onclick="prevpage()"> Previous </button>
+                </div>
+            </div>
+            <div class="column is-3-desktop is-4-tablet is-12-mobile">
+                <div class="v-datalist-container components-list">
+                    <div class="v-datalist-title">Observations</div>
+                    <div id="becobs2">
+
+                    </div>
+                </div>
+            </div>
+        </div>
+        </div>
+    </section>
+
     <script src="https://cdn.jsdelivr.net/gh/virtual-labs/virtual-style@0.0.8-b/js/script.js"></script>
     <script src="./js/binary_erasure_channel.js"></script>
 </body>

--- a/experiment/simulation/binary_symmetric_channel.html
+++ b/experiment/simulation/binary_symmetric_channel.html
@@ -29,7 +29,7 @@
             </div>
             <div class="column">
                 <div class="v-tabs">
-                    <ul>
+                    <ul class="taskbar-tabs">
                         <li id="Task1" onclick="window.location.href = 'binary_erasure_channel.html';">
                             <a>
                                 Binary Erasure Channel

--- a/experiment/simulation/binary_symmetric_channel.html
+++ b/experiment/simulation/binary_symmetric_channel.html
@@ -36,7 +36,7 @@
                             </a>
                         </li>
 
-                        <li class="is-active" id="Task2" >
+                        <li class="is-active" id="Task2">
                             <a>
                                 Binary Symmetric Channel
                             </a>
@@ -75,26 +75,34 @@
                             </li>
 
                             <li>
-                                In the first exercise, you are given a codeword, and you have to identify what are the possible outputs of the Binary Symmetric Channel.
+                                In the first exercise, you are given a codeword, and you have to identify what are the
+                                possible outputs of the Binary Symmetric Channel.
                             </li>
 
                             <li>
-                                After selecting the output vectors accordingly, click on the <b>Submit</b> button. Observations will be displayed accordingly.
+                                After selecting the output vectors accordingly, click on the <b>Submit</b> button.
+                                Observations will be displayed accordingly.
                             </li>
                             <li>
-                                Only after you have selected all the correct output vectors will the <b>Next</b> button appear to go to the next exercise.
+                                Only after you have selected all the correct output vectors will the <b>Next</b> button
+                                appear to go to the next exercise.
                             </li>
                             <li>
-                                Click on the <b>Reset</b> button to reset all your selected choices and restart the exercise.
+                                Click on the <b>Reset</b> button to reset all your selected choices and restart the
+                                exercise.
                             </li>
                             <li>
-                                For the next exercise you must enter the probability of receiving each of the previously selected output vectors, from the input codeword, in the boxes given.
+                                For the next exercise you must enter the probability of receiving each of the previously
+                                selected output vectors, from the input codeword, in the boxes given.
                             </li>
                             <li>
-                                Once you have entered all the values, click on the <b>Submit</b> button. Observations will be displayed accordingly.
+                                Once you have entered all the values, click on the <b>Submit</b> button. Observations
+                                will be displayed accordingly.
                             </li>
                             <li>
-                                Click on the <b>Previous</b> button to go back to the first exercise or the <b>Reset</b> button to reset all your selected choices and restart the experiment from the first exercise.
+                                Click on the <b>Previous</b> button to go back to the first exercise or the <b>Reset</b>
+                                button to reset all your selected choices and restart the experiment from the first
+                                exercise.
                             </li>
                         </ul>
                     </div>
@@ -105,140 +113,145 @@
     <br>
 
 
-    
-    
+
+
     <section id="bscp1" style="display:block ;">
         <div class="columns is-centered">
             <div class="column is-11-desktop is-12-tablet is-12-mobile">
                 <div class="v-datalist-container components-list">
-                <div>
-                    <p>A codeword needs to be sent through a Binary Symmetric Channel \( (BSC(p)) \) as shown below. Select the possible vectors that could be received through this channel.</p>
-                    <div class="box">
-                        <p> \( {x} =\) [<label id="sentCodeword"></label>] &rarr;</p>
-                        <IMG src="./images/bsc.png" alt="Binary Symmetric Channel" style="width:125px;height:125px;">
-                        <p>&rarr; \( {y} \) </p>
-                    </div>
-                </div>
-                </div>
-            </div>
-        </div>
-
-            <div class="columns is-centered is-flex-direction-row is-flex-wrap-wrap is-align-content-start"
-                style="margin-top:-1.5%;">
-                <div class="column is-8-desktop is-12-tablet is-12-mobile">
-                    <div class="box-question">
-                        
-                        
-                            <form action="" method="get" id="f1" onsubmit="return false">
-                            <table align="center">
-                                <tr>
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="a1" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="a2" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="a3" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="a4" onClick="change(id)"></button>
-                                    </div></td>
-                                </tr>
-        
-                                <tr>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="a5" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="a6" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="a7" onClick="change(id)"></button>
-                                    </div></td>
-        
-                                    <td style="padding: 15px;"><div class="code-word">
-                                        <button class="button-2 buttonstyle" id="a8" onClick="change(id)"></button>
-                                    </div></td>
-                                </tr>
-                            </table>
-                            </form>
-                            <br>
-                            <button class="v-button" role="button" onClick= "check1()"> Submit </button>
-					        <button class="v-button" role="button" onClick= "reset()"> Reset </button>
-					        <button class="v-button" id = "nextpagebutton" role="button" style="display:none ;" onclick = "nextpage()"> Next </button>
-                        </div>    
-                    </div>
-                <div class="column is-3-desktop is-4-tablet is-12-mobile">
-                    <div class="v-datalist-container components-list">
-                        <div class="v-datalist-title">Observations</div>
-                        <div id="bscobs1">
-    
-                        </div>
-                        <div id="bscobs12">
-    
+                    <div>
+                        <p>A codeword needs to be sent through a Binary Symmetric Channel \( (BSC(p)) \) as shown below.
+                            Select the possible vectors that could be received through this channel.</p>
+                        <div class="box">
+                            <p> \( {x} =\) [<label id="sentCodeword"></label>] &rarr;</p>
+                            <IMG src="./images/bsc.png" alt="Binary Symmetric Channel"
+                                style="width:125px;height:125px;">
+                            <p>&rarr; \( {y} \) </p>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        </section>
 
-            <section id="bscp2" style="display:none ;">
-            <div class="columns is-centered">
-                <div class="column is-11-desktop is-12-tablet is-12-mobile">
-                    <div class="v-datalist-container components-list">
-                        <p>For the input codeword \( {x} =\) [<p id="newCodeword"></p>] enter the probability of receiving each of the previously selected output vectors on the &nbsp; \(  BSC(p)  \) &nbsp; channel.</p>
+        <div class="columns is-centered is-flex-direction-row is-flex-wrap-wrap is-align-content-start"
+            style="margin-top:-1.5%;">
+            <div class="column is-8-desktop is-12-tablet is-12-mobile">
+                <div class="box-question">
+
+
+                    <form action="" method="get" id="f1" onsubmit="return false">
+                        <div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 15px;">
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="a1" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="a2" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="a3" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="a4" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="a5" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="a6" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="a7" onClick="change(id)"></button>
+                            </div>
+                            <div class="code-word">
+                                <button class="button-2 buttonstyle" id="a8" onClick="change(id)"></button>
+                            </div>
+                        </div>
+                    </form>
+                    
+                    <br>
+                    <button class="v-button" role="button" onClick="check1()"> Submit </button>
+                    <button class="v-button" role="button" onClick="reset()"> Reset </button>
+                    <button class="v-button" id="nextpagebutton" role="button" style="display:none ;"
+                        onclick="nextpage()"> Next </button>
+                </div>
+            </div>
+            <div class="column is-3-desktop is-4-tablet is-12-mobile">
+                <div class="v-datalist-container components-list">
+                    <div class="v-datalist-title">Observations</div>
+                    <div id="bscobs1">
+
+                    </div>
+                    <div id="bscobs12">
+
                     </div>
                 </div>
             </div>
-            <div class="columns is-centered is-flex-direction-row is-flex-wrap-wrap is-align-content-start" style="margin-top:-1.5%;">
-                <div class="column is-8-desktop is-12-tablet is-12-mobile">
-                    <div class="box-question">
+        </div>
+        </div>
+    </section>
+
+    <section id="bscp2" style="display:none ;">
+        <div class="columns is-centered">
+            <div class="column is-11-desktop is-12-tablet is-12-mobile">
+                <div class="v-datalist-container components-list">
+                    <p>For the input codeword \( {x} =\) [
+                    <p id="newCodeword"></p>] enter the probability of receiving each of the previously selected output
+                    vectors on the &nbsp; \( BSC(p) \) &nbsp; channel.</p>
+                </div>
+            </div>
+        </div>
+        <div class="columns is-centered is-flex-direction-row is-flex-wrap-wrap is-align-content-start"
+            style="margin-top:-1.5%;">
+            <div class="column is-8-desktop is-12-tablet is-12-mobile">
+                <div class="box-question">
                     <form action="" method="get" id="f2" onsubmit="return false">
-                <br>
-                <div>
-                    <p style="margin-bottom: 50px;">Enter the probability of receiving each of the previously selected vectors.</p>
-                    <ul>
-                        <li>
-                            <span> (a) Enter the probability of receiving the vector \( {y} =\) <label id = "codeword1"></label>.</span>
-                        </li>
-                        <p>\( p({y}|{x}) = \)<label>\(p\)<sup><input type="number" id="p11" style="width: 2em;"></sup></label>\( (1-p) \)<sup><input type="number" id="p12" style="width: 2em;"></sup></p>
-                        <li>
-                            <span> (b) Enter the probability of receiving the vector \( {y} =\) <label id = "codeword2"></label>.</span>
-                        </li>
-                        <p>\( p({y}|{x}) = \)<label>\(p\)<sup><input type="number" id="p21" style="width: 2em;"></sup></label>\( (1-p) \)<sup><input type="number" id="p22" style="width: 2em;"></sup></p>
-                        <li>
-                            <span> (c) Enter the probability of receiving the vector \( {y} =\) <label id = "codeword3"></label>.</span>
-                        </li>
-                        <p>\( p({y}|{x}) = \)<label> \(p\) <sup><input type="number" id="p31" style="width: 2em;"></sup></label>\( (1-p) \)<sup><input type="number" id="p32" style="width: 2em;"></sup></p>
-                    </ul>
+                        <br>
+                        <div>
+                            <p style="margin-bottom: 50px;">Enter the probability of receiving each of the previously
+                                selected vectors.</p>
+                            <ul>
+                                <li>
+                                    <span> (a) Enter the probability of receiving the vector \( {y} =\) <label
+                                            id="codeword1"></label>.</span>
+                                </li>
+                                <p>\( p({y}|{x}) = \)<label>\(p\)<sup><input type="number" id="p11"
+                                                style="width: 2em;"></sup></label>\( (1-p) \)<sup><input type="number"
+                                            id="p12" style="width: 2em;"></sup></p>
+                                <li>
+                                    <span> (b) Enter the probability of receiving the vector \( {y} =\) <label
+                                            id="codeword2"></label>.</span>
+                                </li>
+                                <p>\( p({y}|{x}) = \)<label>\(p\)<sup><input type="number" id="p21"
+                                                style="width: 2em;"></sup></label>\( (1-p) \)<sup><input type="number"
+                                            id="p22" style="width: 2em;"></sup></p>
+                                <li>
+                                    <span> (c) Enter the probability of receiving the vector \( {y} =\) <label
+                                            id="codeword3"></label>.</span>
+                                </li>
+                                <p>\( p({y}|{x}) = \)<label> \(p\) <sup><input type="number" id="p31"
+                                                style="width: 2em;"></sup></label>\( (1-p) \)<sup><input type="number"
+                                            id="p32" style="width: 2em;"></sup></p>
+                            </ul>
+                        </div>
+                    </form>
+                    <br>
+                    <button class="v-button" role="button" onclick="check2()">Submit</button>
+                    <button class="v-button" role="button" onClick="reset()"> Reset </button>
+                    <button class="v-button" role="button" onclick="prevpage()"> Previous </button>
                 </div>
-            </form>
-            <br>
-            <button class="v-button" role="button" onclick="check2()">Submit</button>
-            <button class="v-button" role="button" onClick= "reset()"> Reset </button>
-            <button class="v-button" role="button" onclick = "prevpage()"> Previous </button>  
-        </div>    
-    </div>
-<div class="column is-3-desktop is-4-tablet is-12-mobile">
-    <div class="v-datalist-container components-list">
-        <div class="v-datalist-title">Observations</div>
-        <div id="bscobs2">
+            </div>
+            <div class="column is-3-desktop is-4-tablet is-12-mobile">
+                <div class="v-datalist-container components-list">
+                    <div class="v-datalist-title">Observations</div>
+                    <div id="bscobs2">
 
+                    </div>
+                </div>
+            </div>
         </div>
         </div>
-    </div>
-</div>
-</div>
 
-</section>
+    </section>
 
     <script src="https://cdn.jsdelivr.net/gh/virtual-labs/virtual-style@0.0.8-b/js/script.js"></script>
     <script src="./js/binary_symmetric_channel.js"></script>

--- a/experiment/simulation/css/binary_erasure_channel.css
+++ b/experiment/simulation/css/binary_erasure_channel.css
@@ -70,3 +70,44 @@
     text-indent: 0%;
   }
 
+/* Responsive MathJax Equations */
+.MathJax {
+    max-width: 100%;
+    display: inline-block;
+}
+
+/* Ensure math containers are responsive */
+.math-container {
+    width: 100%;
+}
+
+/* Hide scrollbars on larger screens */
+@media screen and (min-width: 751px) {
+    .math-container {
+        overflow: visible;
+    }
+    
+    .MathJax {
+        overflow: visible;
+    }
+}
+
+/* Add scrollbars for smaller screens */
+@media screen and (max-width: 750px) {
+    .math-container {
+        overflow-x: auto;
+        overflow-y: hidden;
+    }
+    
+    .MathJax {
+        font-size: 0.8em !important;
+    }
+}
+
+/* Prevent equation overflow */
+.MathJax_Display {
+    max-width: 100%;
+    text-align: center;
+}
+
+

--- a/experiment/simulation/css/main.css
+++ b/experiment/simulation/css/main.css
@@ -117,7 +117,7 @@ input[type=number]::-webkit-outer-spin-button {
 
 input[type=number] {
     -moz-appearance: textfield;
-  }
+}
 
 /* Error Detection */
 
@@ -127,4 +127,14 @@ select {
     border: groove;
     border-radius: 0.2em;
     background-color: #f1f1f1;
-  }
+}
+
+.taskbar-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
+    flex: 1;
+    /* Allow tabs to grow and shrink based on container size */
+    width: 100%;
+    /* Ensure full width of the container */
+}

--- a/experiment/simulation/gaussian_channel.html
+++ b/experiment/simulation/gaussian_channel.html
@@ -70,7 +70,7 @@
             </div>
             <div class="column">
                 <div class="v-tabs">
-                    <ul>
+                    <ul class="taskbar-tabs">
                         <li id="Task1" onclick="window.location.href = 'binary_erasure_channel.html';">
                             <a>
                                 Binary Erasure Channel

--- a/experiment/theory.md
+++ b/experiment/theory.md
@@ -1,6 +1,4 @@
-# Theory 
-
-## What is a Communication Channel? 
+### What is a Communication Channel? 
 
 A communication channel is a medium through which communication happens. In this virtual lab, we are dealing with specifically those channels that accept binary-valued inputs. We call these channels as binary-input channels. For some binary channels, we write the possible set of inputs as the *logical bits* $\{0,1\}$. That is, at any time instant, we can send a logical "0" through the channel, or a logical "1". Equivalently, we may also write the binary alphabet in the *bipolar* form, which is written as $\{+1,-1\}$. Normally, we take the logical-bit to bipolar mapping as $0\to +1$ and $1\to -1$.
 
@@ -8,7 +6,7 @@ A communication channel is a medium through which communication happens. In this
 We generally use the notation $\cal X$ to denote the input alphabet of the channel. From the point of view of the receiver, the input to the channel is unknown, and hence is modelled as a random variable with some input probability distribution. We denote this input random variable as $X$. Similarly, the output of the channel, is a random variable denoted by $Y$. We assume that the output alphabet, the set of all values that the output can possibly take, is denoted by $\cal Y$. 
 
 
-## Types of Channels considered in this virtual lab
+### Types of Channels considered in this virtual lab
 
 The problem of designing good communication systems arises precisely due to the existence of *noise* in communication channels. The noise in the communication channel is generally modelled via the conditional probabilities (of the output value, given the input value). We consider some three important types of communication channels (or in other words, noise models) in this virtual lab.
 
@@ -47,7 +45,7 @@ $$Y=X+Z.$$
 
 ---
 
-## Conditional Distribution Associated with the Communication Channel
+### Conditional Distribution Associated with the Communication Channel
 
 We can also describe the channels above using the conditional distribution of the output random variable $Y$ given by the input random variable $X$. Specifically, we have the following. 
 
@@ -76,7 +74,7 @@ $$
 p_{Y|X}(y|x)=\frac{1}{\sqrt{\pi N_0}}e^{\frac{-(y-x)^2}{N_0}}, \forall x,y \in \mathbb{R}. 
 $$
 
-## The Memoryless Property of the Channels
+### The Memoryless Property of the Channels
 
 We assume that the three channels we have considered in this virtual lab have the *memoryless* property and exist *without feedback*. To be precise, if we transmit a $n$-length sequence of bits denoted by $(x_1,\ldots,x_n)$ through any of these channels, the output is a sequence of bits $(y_1,\ldots,y_n)$, with probability as follows. 
 


### PR DESCRIPTION
## TODO: 

#### 1. Side Menu
- [x] Replace "Binary Channels" in the side menu with "Simulation".

#### 2. Aim
- [x] Remove the "Aim" title from the page.

#### 3. Theory
- [x] Remove the "Theory" title from the page.
- [ ] Adjust the font styles for subtopics to match the design consistency of other pages.

#### 4. Pretest
- [ ] Standardize all incorrect answers' explanations to start with "Incorrect Answer" (Q1e and Q3a)

#### 5. Simulation
- [ ] Optimize the use of screen space for the experiment display.
  - Follow the [VLabs 3-pane template](https://virtual-labs.github.io/exp-adder-circuit-iiith/practice.html).
- [ ] Make the simulation mobile-friendly.
- [ ] Add an "Instructions" section to guide users on interacting with the simulation.

#### 6. Posttest
- [ ] Ensure all incorrect answers' explanations are consistent across the page.
  - Use "Incorrect Answer" as the standard phrase for all explanations.

---

## Follow-Up Notes

#### 1. Side Menu
-  Is it required to replace "Binary Channels" in the side menu with "Simulation" ?

#### 2. Pretest
- Q1e seems fine to me

#### 3. Simulation
-  "Instructions" section is already present
- wrapping for BEC and BSC (avoid left right scrolling)
- adjust image size according to device

#### 4. Posttest
- Options seem fine to me
